### PR TITLE
Convert release workflow from docker buildx bake to paws

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,38 +4,86 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
   push:
     tags:
       - "*"
-
-env:
-  GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
-  bake:
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        if: github.ref_type == 'tag'
-        uses: docker/login-action@v4
+      - uses: actions/checkout@v7
         with:
-          username: mbround18
-          password: ${{ secrets.DOCKER_TOKEN }}
+          fetch-depth: 0
 
-      - name: Bake
-        if: github.ref_type != 'tag'
-        run: docker buildx bake
+      - uses: mbround18/paws/actions/paws-up@main
 
-      - name: Bake and push
-        if: github.ref_type == 'tag'
-        run: docker buildx bake --push
+      - name: Resolve release version
+        id: resolve
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            version="${{ github.ref_name }}"
+          else
+            version=$(paws semver --branch main)
+          fi
+          echo "Resolved version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  docker-release:
+    needs: version
+    name: paws docker (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: palworld
+            image: mbround18/palworld-docker
+          - target: installer
+            image: mbround18/palworld-docker-installer
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: mbround18/paws/actions/paws-up@main
+
+      - name: paws docker (${{ matrix.target }})
+        env:
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          paws docker \
+            --image "${{ matrix.image }}" \
+            --version "${{ needs.version.outputs.version }}" \
+            --target "${{ matrix.target }}" \
+            --registries ghcr.io \
+            --with-latest \
+            --dockerhub-username mbround18 \
+            --ghcr-username mbround18
+
+  tagger:
+    needs: [version, docker-release]
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: mbround18/paws/actions/paws-up@main
+
+      - name: Compute and push next tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: paws semver --branch main --push

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN apt-get update                        \
         cron sudo gosu dos2unix  jq       \
         tzdata                            \
     && rm -rf /var/lib/apt/lists/*        \
-    && gosu nobody true                   \
-    && dos2unix
+    && gosu nobody true
 
 # Remove any existing user or group with ID 1000
 RUN if getent passwd 1000 > /dev/null; then userdel $(getent passwd 1000 | cut -d: -f1); fi \


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled QEMU/Buildx/`docker buildx bake` pipeline with `paws docker` + `paws semver`, matching the `redirect`/`steamcmd-bases` conversion shape.
- Two images build from the existing `Dockerfile` targets: `mbround18/palworld-docker` (target `palworld`) and `mbround18/palworld-docker-installer` (target `installer`), matrixed in one `docker-release` job.
- Adds auto-versioning: `paws semver` resolves a version on pushes to `main`, tag pushes use the tag itself, and a `tagger` job pushes the next tag (+ GitHub Release) on merge to `main` — this repo previously only released on a manually pushed tag.
- Adds `ghcr.io` publishing alongside Docker Hub (both `DOCKER_TOKEN`/`GHCR_TOKEN` secrets already exist in this repo).

## Test plan
- [ ] PR CI: `docker-release` matrix builds both targets without pushing (canary/PR gating handled internally by `paws docker`)
- [ ] Merge to `main`: `tagger` job cuts a new tag + GitHub Release
- [ ] Tag push: `docker-release` publishes `mbround18/palworld-docker` and `mbround18/palworld-docker-installer` to Docker Hub + ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)